### PR TITLE
Add floating point support to `HsImage` and loaders

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from math import inf
-from typing import Generic, Optional, TypeAlias, TypeVar, Callable, Any
+from typing import Any, Callable, Generic, Optional, TypeAlias, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -186,7 +186,9 @@ class HsImage(Generic[ScalarType]):
         if self.norm_div is None or self.norm_min is None:
             return self.data
         else:
-            return (self.data - self.norm_min) / self.norm_div
+            scaled = (self.data - self.norm_min) / self.norm_div
+            scaled[~self.pos_mask] = 0
+            return scaled
 
     def get_norm_prop(self, *args: tuple[int] | tuple[int, int, int]):
         if self.normalisation == NormalisationMethod.GLOBAL:
@@ -218,7 +220,9 @@ class HsImage(Generic[ScalarType]):
             if norm_data is None:
                 return func(self, *args)
             norm_min, norm_max = norm_data
-            return (func(self, *args) - norm_min) / norm_max
+            scaled = (func(self, *args) - norm_min) / norm_max
+            scaled[scaled < 0] = 0
+            return scaled
 
         return wrapper
 

--- a/lib.py
+++ b/lib.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.typing as npt
 
 Coordinates: TypeAlias = tuple[int, int]
-ScalarType = TypeVar("ScalarType", bound=np.generic, covariant=True)
+ScalarType = TypeVar("ScalarType", np.floating, np.signedinteger, np.unsignedinteger)
 
 
 class LabelType(Enum):
@@ -26,18 +26,57 @@ class LabelType(Enum):
     """Custom string labels, conversion to numeric type should not be attempted"""
 
 
+class NormalisationMethod(Enum):
+    """Defines how floating point data should be normalised."""
+
+    GLOBAL = 1
+    """Global maximum and minimum (excluding negative values) should be used as 1 and 0"""
+    BAND = 2
+    """Maximum and minimum must be separate for each band"""
+
+
 class HsImage(Generic[ScalarType]):
     """Hyperspectral image data"""
 
     def __init__(
         self,
         data: npt.NDArray[ScalarType],
-        bpp: int,
+        bpp: Optional[int] = None,
+        normalisation: Optional[NormalisationMethod] = None,
         labels: Optional[list[str]] = None,
         labels_type: Optional[LabelType] = None,
     ) -> None:
         if data.ndim != 3:
             raise ValueError('"data" parameter must have 3 dimensions')
+
+        pos_mask = data >= 0
+
+        if (data.dtype.kind == "i" or data.dtype.kind == "u") and bpp is None:
+            raise RuntimeError("Integer data loaded, but bpp is None")
+        if data.dtype.kind == "f":
+            match normalisation:
+                case None:
+                    raise RuntimeError(
+                        "Floating point dara loaded, but normalisation is None"
+                    )
+                case NormalisationMethod.GLOBAL:
+                    ax = None
+                case NormalisationMethod.BAND:
+                    ax = (0, 1)
+
+            norm_min = np.amin(data, axis=ax, initial=np.inf, where=pos_mask)
+            norm_max = np.amax(data, axis=ax, initial=-np.inf, where=pos_mask)
+
+            if ax is None and (norm_min == np.inf or norm_max == -np.inf):
+                raise ValueError(
+                    "Image contains invalid data - all values are negative or infinity."
+                )
+            if ax is not None:
+                norm_min[norm_min == np.inf] = 0
+                norm_max[norm_max == -np.inf] = 0
+
+            self.norm_div: Optional[npt.NDArray | float] = norm_max - norm_min
+            self.norm_min: Optional[npt.NDArray | float] = norm_min
 
         bands = data.shape[2]
         if labels is None:
@@ -53,14 +92,17 @@ class HsImage(Generic[ScalarType]):
                 labels_type = LabelType.CUSTOM_STR
 
         self.data = data
+        self.normalisation = normalisation
         self.bpp = bpp
-        """Bits per pixel"""
+        """Bits per pixel for integer data"""
         self.labels = labels
         """Labels for all bands"""
         self.labels_type = labels_type
         """Origin and type of labels"""
         self.bands = bands
         """Number of bands in the image"""
+        self.pos_mask = pos_mask
+        """A boolean mask of non-negative data"""
 
     def get_pixel(self, x: int, y: int) -> npt.NDArray[ScalarType]:
         """Returns a single pixel of the image as a 1D `ndarray`."""
@@ -81,8 +123,11 @@ class HsImage(Generic[ScalarType]):
         """Returns a truth mask of pixels similar to the one with `base_coordinates` within threshold defined as percent of the maximum MSE (depends on `bpp`)."""
         base = self.data[base_coordinates]
         h, w, b = self.data.shape
-        threshold = ((1 << self.bpp) - 1) ** 2 * threshold_percent / 100
-        flattened = self.data.reshape((h * w, b))
+        if self.bpp is not None:
+            threshold = ((1 << self.bpp) - 1) ** 2 * threshold_percent / 100
+        else:
+            threshold = threshold_percent / 100.0
+        flattened = self.normalise(self.data).reshape((h * w, b))
         mse: npt.NDArray[np.float_] = (
             np.square(flattened - base).mean(axis=1).reshape((h, w))
         )
@@ -133,3 +178,10 @@ class HsImage(Generic[ScalarType]):
 
         if max(diff_r, diff_g, diff_b) < 30:
             return r_idx, g_idx, b_idx
+
+    def normalise(self, data: npt.NDArray[ScalarType]):
+        """Normalise floating point data to [0, 1] range. Integer data is left unchanged."""
+        if self.norm_div is None or self.norm_min is None:
+            return data
+        else:
+            return (data - self.norm_min) / self.norm_div

--- a/lib.py
+++ b/lib.py
@@ -183,7 +183,7 @@ class HsImage(Generic[ScalarType]):
 
     def normalised(self):
         """Returns image data normalised to [0, 1] range if the data is integer. Integer data is left unchanged."""
-        if self.norm_div is None or self.norm_min is None:
+        if self.normalisation is None:
             return self.data
         else:
             scaled = (self.data - self.norm_min) / self.norm_div
@@ -243,6 +243,9 @@ class HsImage(Generic[ScalarType]):
         bpp_diff = self.bpp - 8
         # Type conversion to uint8 is time consuming, but Qt expects data in such format.
         # We cant just pass 32-bit values capped at 255
-        rounded = ((data + (1 << (bpp_diff - 1))) >> bpp_diff).astype(np.uint8)
+        if bpp_diff:
+            rounded = ((data + (1 << (bpp_diff - 1))) >> bpp_diff).astype(np.uint8)
+        else:
+            rounded = data.astype(np.uint8)
         rounded[rounded < 0] = 0
         return rounded

--- a/lib.py
+++ b/lib.py
@@ -127,7 +127,7 @@ class HsImage(Generic[ScalarType]):
             threshold = ((1 << self.bpp) - 1) ** 2 * threshold_percent / 100
         else:
             threshold = threshold_percent / 100.0
-        flattened = self.normalise(self.data).reshape((h * w, b))
+        flattened = self.normalised().reshape((h * w, b))
         mse: npt.NDArray[np.float_] = (
             np.square(flattened - base).mean(axis=1).reshape((h, w))
         )
@@ -179,9 +179,9 @@ class HsImage(Generic[ScalarType]):
         if max(diff_r, diff_g, diff_b) < 30:
             return r_idx, g_idx, b_idx
 
-    def normalise(self, data: npt.NDArray[ScalarType]):
-        """Normalise floating point data to [0, 1] range. Integer data is left unchanged."""
+    def normalised(self):
+        """Returns image data normalised to [0, 1] range if the data is integer. Integer data is left unchanged."""
         if self.norm_div is None or self.norm_min is None:
-            return data
+            return self.data
         else:
-            return (data - self.norm_min) / self.norm_div
+            return (self.data - self.norm_min) / self.norm_div

--- a/loaders/abstract.py
+++ b/loaders/abstract.py
@@ -1,9 +1,12 @@
 from abc import ABC, abstractmethod
+from math import ceil, log2
 from typing import Optional
 
-from PyQt6.QtWidgets import QWidget
+import numpy as np
+import numpy.typing as npt
+from PyQt6.QtWidgets import QInputDialog, QWidget
 
-from lib import HsImage
+from lib import HsImage, NormalisationMethod, ScalarType
 from utils import staticproperty
 
 
@@ -35,3 +38,36 @@ class AbstractFileLoader(ABC):
         Returns `None` if user cancels the operation.
         """
         pass
+
+    @staticmethod
+    def get_normalisation(parent: QWidget) -> Optional[NormalisationMethod]:
+        GLOBAL = "Global"
+        BAND = "Per band"
+        norm, ok = QInputDialog.getItem(
+            parent,
+            "Whaaale - open file",
+            "Normalisation method:",
+            [GLOBAL, BAND],
+            editable=False,
+        )
+        if norm == GLOBAL:
+            return NormalisationMethod.GLOBAL
+        if norm == BAND:
+            return NormalisationMethod.BAND
+
+    @staticmethod
+    def get_bpp(data: npt.NDArray[ScalarType], parent: QWidget) -> Optional[int]:
+        max = data.dtype.itemsize * 8
+        max_val: ScalarType = np.max(data)
+        min_bpp = ceil(log2(max_val))
+
+        bpp, ok = QInputDialog.getInt(
+            parent,
+            "Whaaale - open file",
+            "Bits per pixel:",
+            min=min_bpp,
+            max=max,
+        )
+
+        if ok:
+            return bpp

--- a/loaders/matlab.py
+++ b/loaders/matlab.py
@@ -1,4 +1,3 @@
-from math import ceil, log2
 from typing import Any, BinaryIO, Optional
 
 import h5py
@@ -7,7 +6,7 @@ import numpy.typing as npt
 import scipy.io as sio
 from PyQt6.QtWidgets import QInputDialog, QWidget
 
-from lib import HsImage, ScalarType
+from lib import HsImage
 from loaders.abstract import AbstractFileLoader
 from utils import staticproperty
 
@@ -36,14 +35,23 @@ class MatlabLoader(AbstractFileLoader):
         # Extract data as NumPy array
         # https://docs.h5py.org/en/stable/whatsnew/2.1.html#dataset-value-property-is-now-deprecated
         var: npt.NDArray = data[var_name][()]
-        if var.dtype.kind != "i" and var.dtype.kind != "u":
+        if var.dtype.kind != "i" and var.dtype.kind != "u" and var.dtype.kind != "f":
             raise NotImplementedError(
-                f"Only integer types are supported, file uses {var.dtype.name}."
+                f"Only integer and floating point types are supported, file uses {var.dtype.name}."
             )
-        bpp = MatlabLoader.get_bpp(var, parent)
-        if bpp is None:
-            return
-        image = HsImage(var, bpp)
+
+        if var.dtype.kind == "f":
+            bpp = None
+            normalisation = MatlabLoader.get_normalisation(parent)
+            if normalisation is None:
+                return
+        else:
+            bpp = MatlabLoader.get_bpp(var, parent)
+            if bpp is None:
+                return
+            normalisation = None
+
+        image = HsImage(var, bpp=bpp, normalisation=normalisation)
         return image
 
     @staticmethod
@@ -58,7 +66,7 @@ class MatlabLoader(AbstractFileLoader):
         if var_name is None:
             return
 
-        var: npt.NDArray[ScalarType] = data[var_name]
+        var: npt.NDArray = data[var_name]
         if var.dtype.kind != "i" and var.dtype.kind != "u":
             raise NotImplementedError(
                 f"Only integer types are supported, file uses {var.dtype.name}"
@@ -83,24 +91,6 @@ class MatlabLoader(AbstractFileLoader):
             var_name = names[0]
 
         return var_name
-
-    @staticmethod
-    def get_bpp(data: npt.NDArray[ScalarType], parent: QWidget) -> Optional[int]:
-        MAX_BPP = 32
-        max_val: ScalarType = np.max(data)
-        min_bpp = ceil(log2(max_val))
-
-        bpp, ok = QInputDialog.getInt(
-            parent,
-            MatlabLoader.DIALOG_TITLE,
-            "Bits per pixel:",
-            min=min_bpp,
-            max=MAX_BPP,
-        )
-
-        if not ok:
-            return
-        return bpp
 
     @staticmethod
     def select_var(


### PR DESCRIPTION
Partially implements #18. Image preview has not been adjusted, because it doesn't exist yet, but some helper methods have been added.

## `HsImage` changes

### Constructor

- `bpp` is required for integer arrays, but will be ignored with floating point data.
- `normalisation` is a new parameter, which is required for floating point arrays

### New properties

- `pos_mask` a boolean mask with correct (non-negative) data.

### New methods

- `normalised()` returns the data in normalised form (floating point only), integer data is left unchanged

## `NormalisationMethod` enum

Used to specify the normalisation method for `HsImage`. `GLOBAL` uses global minima and maxima, while `BAND` has a separate min/max for each band.